### PR TITLE
Compact layout

### DIFF
--- a/Symbol Organizer.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/Symbol Organizer.sketchplugin/Contents/Sketch/script.cocoascript
@@ -21,6 +21,8 @@ var onRun = function(context) {
 				var y = 0;
 				var xPad = parseInt(layoutSettings.xPad);
 				var yPad = parseInt(layoutSettings.yPad);
+				var xStackPad = xPad/2;
+				var yStackPad = yPad/2;
 				var maxPer = (layoutSettings.maxPer > 0) ? layoutSettings.maxPer : 0;
 
 				// Title variables
@@ -147,6 +149,8 @@ var onRun = function(context) {
 
 					// Set tracker/counters
 					var groupSpace = 0;
+					var stackOffset = 0;
+					var stackSpace = 0;
 					var groupCount = 1;
 					var objectCount = 1;
 
@@ -191,6 +195,10 @@ var onRun = function(context) {
 							// Reset the group space tracker
 							groupSpace = 0;
 
+							// Reset the stack space tackers
+							stackOffset = 0;
+							stackSpace = 0;
+
 							// Increment the group counter
 							groupCount++;
 
@@ -214,16 +222,50 @@ var onRun = function(context) {
 							// Reset the group space tracker
 							groupSpace = 0;
 
+							// Reset the stack space tacker
+							stackOffset = 0;
+							stackSpace = 0;
+
 							// Reset the object counter
 							objectCount = 1;
 						}
 
 						// Position the symbol
-						symbolFrame.x = x;
-						symbolFrame.y = y;
+						if (layoutSettings.sortDirection == 0) {
+							// If the symbol can't be stacked
+							if (stackOffset + symbolFrame.width() > groupLayout[i]['groupMax']){
+								// Increase the y position
+								y += stackSpace + yPad;
 
-						// asdf
-						log(symbol.name() + " " + x + " " + y + " " + groupLayout[i]['groupMax']);
+								// Reset stack					
+								stackOffset = 0;
+								stackSpace = 0;
+							}
+
+							// Position the symbol
+							symbolFrame.y = y;
+							symbolFrame.x = x + stackOffset;
+
+							// Increase stackOffset for next symbol
+							stackOffset += symbolFrame.width() + xStackPad;
+						} else {
+							// If the symbol can't be stacked
+							if (stackOffset + symbolFrame.height() > groupLayout[i]['groupMax']){
+								// Increase the x position
+								x += stackSpace + xPad;
+
+								// Reset stack					
+								stackOffset = 0;
+								stackSpace = 0;
+							}
+
+							// Position the symbol
+							symbolFrame.x = x;
+							symbolFrame.y = y + stackOffset;
+
+							// Increase stackOffset for next symbol
+							stackOffset += symbolFrame.height() + yStackPad;
+						}
 
 						// Update group position variables per the layout direction
 						if (layoutSettings.sortDirection == 0) {
@@ -233,8 +275,11 @@ var onRun = function(context) {
 								groupSpace = symbolFrame.width();
 							}
 
-							// Set the y position for the next symbol
-							y += symbolFrame.height() + yPad;
+							// If this symbol is taller than previous symbols in stack
+							if (symbolFrame.height() > stackSpace) {
+								// Increase the height of the stack
+								stackSpace = symbolFrame.height();
+							}
 						} else {
 							// If this symbol is taller than previous symbols in row
 							if (symbolFrame.height() > groupSpace) {
@@ -242,8 +287,11 @@ var onRun = function(context) {
 								groupSpace = symbolFrame.height();
 							}
 
-							// Set the x position for the next symbol
-							x += symbolFrame.width() + xPad;
+							// If this symbol is wider than previous symbols in stack
+							if (symbolFrame.width() > stackSpace) {
+								// Increase the width of the stack
+								stackSpace = symbolFrame.width();
+							}
 						}
 
 						// Increment the object counter

--- a/Symbol Organizer.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/Symbol Organizer.sketchplugin/Contents/Sketch/script.cocoascript
@@ -222,6 +222,9 @@ var onRun = function(context) {
 						symbolFrame.x = x;
 						symbolFrame.y = y;
 
+						// asdf
+						log(symbol.name() + " " + x + " " + y + " " + groupLayout[i]['groupMax']);
+
 						// Update group position variables per the layout direction
 						if (layoutSettings.sortDirection == 0) {
 							// If this symbol is wider than previous symbols in row
@@ -611,11 +614,15 @@ var onRun = function(context) {
 		var groupLayout = [];
 		var lastGroupPrefix;
 
+		// Per-group variables;
+		var groupMax = [];
+
 		// Iterate through the symbols
 		for (var i = 0; i < symbols.count(); i++) {
 			// Symbol variables
 			var symbol = symbols.objectAtIndex(i);
 			var symbolName = symbol.name();
+			var symbolFrame = symbol.frame();
 
 			// Determine a break point in the symbol name
 			var breakPoint = (symbolName.indexOf("/") != -1) ? getCharPosition(symbolName,"/",depth+1) : 0;
@@ -627,6 +634,23 @@ var onRun = function(context) {
 			if (lastGroupPrefix != thisGroupPrefix) {
 				// Increment the group counter
 				groupCount++;
+				// Initialize groupMax
+				groupMax[groupCount] = 0;
+			}
+
+			// Compute the max width or height of the current group
+			if (layoutSettings.sortDirection == 0) {
+				// If this symbol is wider than previous symbols in this group
+				if (symbolFrame.width() > groupMax[groupCount]) {
+					// Increase the max width of this group
+					groupMax[groupCount] = symbolFrame.width();
+				}
+			} else {
+				// If this symbol is taller than previous symbols in this group
+				if (symbolFrame.height() > groupMax[groupCount]) {
+					// Increase the max height of this group
+					groupMax[groupCount] = symbolFrame.height();
+				}
 			}
 
 			// Add an entry to the group object
@@ -637,6 +661,12 @@ var onRun = function(context) {
 
 			// Set the last group prefix to current prefix
 			lastGroupPrefix = thisGroupPrefix;
+		}
+
+		// Iterate through groupLayout to set groupMax for each symbol
+		for (var i = 0; i < groupLayout.length; i++){
+			groupCount = groupLayout[i]["group"];
+			groupLayout[i]["groupMax"] = groupMax[groupCount];
 		}
 
 		return groupLayout;

--- a/Symbol Organizer.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/Symbol Organizer.sketchplugin/Contents/Sketch/script.cocoascript
@@ -230,41 +230,55 @@ var onRun = function(context) {
 							objectCount = 1;
 						}
 
-						// Position the symbol
-						if (layoutSettings.sortDirection == 0) {
-							// If the symbol can't be stacked
-							if (stackOffset + symbolFrame.width() > groupLayout[i]['groupMax']){
-								// Increase the y position
-								y += stackSpace + yPad;
-
-								// Reset stack					
-								stackOffset = 0;
-								stackSpace = 0;
-							}
-
-							// Position the symbol
-							symbolFrame.y = y;
-							symbolFrame.x = x + stackOffset;
-
-							// Increase stackOffset for next symbol
-							stackOffset += symbolFrame.width() + xStackPad;
-						} else {
-							// If the symbol can't be stacked
-							if (stackOffset + symbolFrame.height() > groupLayout[i]['groupMax']){
-								// Increase the x position
-								x += stackSpace + xPad;
-
-								// Reset stack					
-								stackOffset = 0;
-								stackSpace = 0;
-							}
-
+						// If not using compact layout...
+						if(layoutSettings.compactLayout == 0){
 							// Position the symbol
 							symbolFrame.x = x;
-							symbolFrame.y = y + stackOffset;
+							symbolFrame.y = y;
 
-							// Increase stackOffset for next symbol
-							stackOffset += symbolFrame.height() + yStackPad;
+							if (layoutSettings.sortDirection == 0) {
+								// Set the y position for the next symbol
+								y += symbolFrame.height() + yPad;
+							} else {
+								// Set the x position for the next symbol
+								x += symbolFrame.width() + xPad;
+							}
+						} else {
+							if (layoutSettings.sortDirection == 0) {
+								// If the symbol can't be stacked
+								if (stackOffset + symbolFrame.width() > groupLayout[i]['groupMax']){
+									// Increase the y position
+									y += stackSpace + yPad;
+
+									// Reset stack					
+									stackOffset = 0;
+									stackSpace = 0;
+								}
+
+								// Position the symbol
+								symbolFrame.y = y;
+								symbolFrame.x = x + stackOffset;
+
+								// Increase stackOffset for next symbol
+								stackOffset += symbolFrame.width() + xStackPad;
+							} else {
+								// If the symbol can't be stacked
+								if (stackOffset + symbolFrame.height() > groupLayout[i]['groupMax']){
+									// Increase the x position
+									x += stackSpace + xPad;
+
+									// Reset stack					
+									stackOffset = 0;
+									stackSpace = 0;
+								}
+
+								// Position the symbol
+								symbolFrame.x = x;
+								symbolFrame.y = y + stackOffset;
+
+								// Increase stackOffset for next symbol
+								stackOffset += symbolFrame.height() + yStackPad;
+							}
 						}
 
 						// Update group position variables per the layout direction
@@ -337,6 +351,7 @@ var onRun = function(context) {
 		var defaultSettings = {};
 		defaultSettings.groupDepth = 1;
 		defaultSettings.displayTitles = 0;
+		defaultSettings.compactLayout = 1;
 		defaultSettings.sortDirection = 0;
 		defaultSettings.xPad = '100';
 		defaultSettings.yPad = '100';
@@ -355,20 +370,23 @@ var onRun = function(context) {
 		alertWindow.setMessageText(pluginName);
 
 		// Grouping options
-		var groupFrame = NSView.alloc().initWithFrame(NSMakeRect(0,0,300,124));
+		var groupFrame = NSView.alloc().initWithFrame(NSMakeRect(0,0,300,152));
 		alertWindow.addAccessoryView(groupFrame);
 
-		var groupGranularityLabel = createLabel('Group Definition',12,NSMakeRect(0,108,140,16));
+		var groupGranularityLabel = createLabel('Group Definition',12,NSMakeRect(0,136,140,16));
 		groupFrame.addSubview(groupGranularityLabel);
 
-		var groupGranularityDescription = createDescription('Symbol Organizer uses a "/" in the name of each symbol to define the groups. This setting determines which "/" should be used.',11,NSMakeRect(0,62,300,42));
+		var groupGranularityDescription = createDescription('Symbol Organizer uses a "/" in the name of each symbol to define the groups. This setting determines which "/" should be used.',11,NSMakeRect(0,90,300,42));
 		groupFrame.addSubview(groupGranularityDescription);
 
-		var groupGranularityValue = createSelect(['1st','2nd','3rd','4th','5th','6th','7th','8th'],defaultSettings.groupDepth,NSMakeRect(0,26,60,28));
+		var groupGranularityValue = createSelect(['1st','2nd','3rd','4th','5th','6th','7th','8th'],defaultSettings.groupDepth,NSMakeRect(0,54,60,28));
 		groupFrame.addSubview(groupGranularityValue);
 
-		var groupTitlesCheckbox = createCheckbox({name:"Display group titles",value:1},defaultSettings.displayTitles,NSMakeRect(0,0,300,18));
+		var groupTitlesCheckbox = createCheckbox({name:"Display group titles",value:1},defaultSettings.displayTitles,NSMakeRect(0,28,300,18));
 		groupFrame.addSubview(groupTitlesCheckbox);
+
+		var compactLayoutCheckbox = createCheckbox({name:"Compact layout",value:1},defaultSettings.compactLayout,NSMakeRect(0,0,300,18));
+		groupFrame.addSubview(compactLayoutCheckbox);
 
 		// Layout options
 		var layoutFrame = NSView.alloc().initWithFrame(NSMakeRect(0,0,300,239));
@@ -425,6 +443,7 @@ var onRun = function(context) {
 		setKeyOrder(alertWindow,[
 			groupGranularityValue,
 			groupTitlesCheckbox,
+			compactLayoutCheckbox,
 			layoutDirectionValue,
 			layoutHorizontalValue,
 			layoutVerticalValue,
@@ -441,6 +460,7 @@ var onRun = function(context) {
 			try {
 				[command setValue:[groupGranularityValue indexOfSelectedItem] forKey:"groupDepth" onLayer:page];
 				[command setValue:[groupTitlesCheckbox state] forKey:"displayTitles" onLayer:page];
+				[command setValue:[compactLayoutCheckbox state] forKey:"compactLayout" onLayer:page];
 				[command setValue:[[layoutDirectionValue selectedCell] tag] forKey:"sortDirection" onLayer:page];
 				[command setValue:[layoutHorizontalValue stringValue] forKey:"xPad" onLayer:page];
 				[command setValue:[layoutVerticalValue stringValue] forKey:"yPad" onLayer:page];
@@ -456,6 +476,7 @@ var onRun = function(context) {
 			return {
 				groupDepth : [groupGranularityValue indexOfSelectedItem],
 				displayTitles : [groupTitlesCheckbox state],
+				compactLayout : [compactLayoutCheckbox state],
 				sortDirection : [[layoutDirectionValue selectedCell] tag],
 				xPad : [layoutHorizontalValue stringValue],
 				yPad : [layoutVerticalValue stringValue],


### PR DESCRIPTION
Hi Jason,

Great plugin, I was thinking of building a similar one myself!

Splitting the symbols by groups and sorting them alphabetically within groups makes sense. However I've noticed that the resulting layout can still be quite sparse, since each group is displayed in a single line (that can wrap after a set number of symbols). Since my projects have a lot of symbols with very different sizes (like icons vs entire screens), the symbols page ends up being very large but with lots of whitespace.

To address this problem, I've added a "compact layout" setting which stacks smaller symbols when the row is tall enough to allow it. That way, having a mix of large symbols and small symbols in the same group doesn't create a lot of wasted space. This is just a first attempt at solving this problem; I'd be curious to hear what you think!

Cheers,
Antoine