### PR TITLE
Update for compatibility with Sketch 2025.1 and after

### DIFF
--- a/Symbol Organizer.sketchplugin/Contents/Sketch/functions.js
+++ b/Symbol Organizer.sketchplugin/Contents/Sketch/functions.js
@@ -328,7 +328,7 @@ function getExemptSymbols() {
 
 	while (page = pageLoop.nextObject()) {
 		var predicate = NSPredicate.predicateWithFormat("className == %@ && overrides != nil","MSSymbolInstance"),
-			instancesWithOverrides = page.layers().filteredArrayUsingPredicate(predicate),
+			instancesWithOverrides = page.childrenIncludingSelf(true).filteredArrayUsingPredicate(predicate),
 			loop = instancesWithOverrides.objectEnumerator(),
 			instance;
 

--- a/Symbol Organizer.sketchplugin/Contents/Sketch/functions.js
+++ b/Symbol Organizer.sketchplugin/Contents/Sketch/functions.js
@@ -49,7 +49,7 @@ function createTextStyle(styleData) {
 	textStyle.setLineHeight(styleData.lineHeight);
 	textStyle.setTextAlignment(styleData.textAlignment);
 	textStyle.setFontPostscriptName(styleData.fontFace);
-	textStyle.setTextColor(MSImmutableColor.colorWithSVGString("#" + styleData.fontColor));
+	textStyle.setTextColor(MSColor.colorWithHex_alpha("#" + styleData.fontColor, 1))
 
 	return textStyle;
 }

--- a/Symbol Organizer.sketchplugin/Contents/Sketch/functions.js
+++ b/Symbol Organizer.sketchplugin/Contents/Sketch/functions.js
@@ -328,7 +328,7 @@ function getExemptSymbols() {
 
 	while (page = pageLoop.nextObject()) {
 		var predicate = NSPredicate.predicateWithFormat("className == %@ && overrides != nil","MSSymbolInstance"),
-			instancesWithOverrides = page.children().filteredArrayUsingPredicate(predicate),
+			instancesWithOverrides = page.layers().filteredArrayUsingPredicate(predicate),
 			loop = instancesWithOverrides.objectEnumerator(),
 			instance;
 

--- a/Symbol Organizer.sketchplugin/Contents/Sketch/script.js
+++ b/Symbol Organizer.sketchplugin/Contents/Sketch/script.js
@@ -308,7 +308,9 @@ var organize = function(context,type) {
 		// If user wants to zoom out...
 		if (layoutSettings.zoomOut == 1) {
 			// Adjust view
-			if (sketch.version.sketch > 64) {
+			if (sketch.version.sketch > 2025) {
+				context.document.canvasView().centerLayersInCanvas();	
+			} else if (sketch.version.sketch > 64) {
 				context.document.canvasView().zoomToFitRect(page.contentBounds());
 			} else {
 				context.document.contentDrawView().zoomToFitRect(page.contentBounds());

--- a/Symbol Organizer.sketchplugin/Contents/Sketch/script.js
+++ b/Symbol Organizer.sketchplugin/Contents/Sketch/script.js
@@ -329,7 +329,7 @@ var remove = function(context) {
 		count = 0;
 
 	var predicate = NSPredicate.predicateWithFormat("className == %@ && isSafeToDelete == 1","MSSymbolMaster"),
-		symbols = context.document.currentPage().children().filteredArrayUsingPredicate(predicate);
+		symbols = context.document.currentPage().layers().filteredArrayUsingPredicate(predicate);
 
 	symbols.forEach(function(symbol){
 		if (exemptSymbols.indexOf(String(symbol.symbolID())) == -1) removeSymbols.push(symbol);

--- a/Symbol Organizer.sketchplugin/Contents/Sketch/script.js
+++ b/Symbol Organizer.sketchplugin/Contents/Sketch/script.js
@@ -164,7 +164,6 @@ var organize = function(context,type) {
 			titleGroup.frame().setX((layoutSettings.sortDirection == 0) ? 0 : -xPad);
 			titleGroup.frame().setY((layoutSettings.sortDirection == 0) ? -(offsetHeight+yPad) : 0);
 			titleGroup.setIsLocked(true);
-			titleGroup.setHasClickThrough(true);
 		}
 
 		// Set tracker/counters

--- a/Symbol Organizer.sketchplugin/Contents/Sketch/script.js
+++ b/Symbol Organizer.sketchplugin/Contents/Sketch/script.js
@@ -93,7 +93,12 @@ var organize = function(context,type) {
 		var groupLayout = createGroupObject(symbols,layoutSettings.groupDepth);
 
 		// Reset page origin
-		page.setRulerBase(CGPointMake(0,0));
+		var hRulerData = page.horizontalRulerData() || MSRulerData.new();    
+		var vRulerData = page.verticalRulerData() || MSRulerData.new();
+		hRulerData.setBase(0);
+		page.setHorizontalRulerData(hRulerData);
+		vRulerData.setBase(0);
+		page.setVerticalRulerData(vRulerData);
 
 		// If user wants to display group titles...
 		if (layoutSettings.displayTitles == 1) {

--- a/Symbol Organizer.sketchplugin/Contents/Sketch/script.js
+++ b/Symbol Organizer.sketchplugin/Contents/Sketch/script.js
@@ -335,7 +335,7 @@ var remove = function(context) {
 		count = 0;
 
 	var predicate = NSPredicate.predicateWithFormat("className == %@ && isSafeToDelete == 1","MSSymbolMaster"),
-		symbols = context.document.currentPage().layers().filteredArrayUsingPredicate(predicate);
+		symbols = context.document.currentPage().childrenIncludingSelf(true).filteredArrayUsingPredicate(predicate);
 
 	symbols.forEach(function(symbol){
 		if (exemptSymbols.indexOf(String(symbol.symbolID())) == -1) removeSymbols.push(symbol);

--- a/Symbol Organizer.sketchplugin/Contents/Sketch/script.js
+++ b/Symbol Organizer.sketchplugin/Contents/Sketch/script.js
@@ -297,7 +297,9 @@ var organize = function(context,type) {
 			page.addLayers([titleGroup]);
 
 			// Resize title group
-			if (sketch.version.sketch > 52) {
+			if (sketch.version.sketch > 2025) {
+				titleGroup.resizeToFitChildren();
+			} else if (sketch.version.sketch > 52) {
 				titleGroup.fixGeometryWithOptions(0);
 			} else {
 				titleGroup.resizeToFitChildrenWithOption(0);

--- a/Symbol Organizer.sketchplugin/Contents/Sketch/script.js
+++ b/Symbol Organizer.sketchplugin/Contents/Sketch/script.js
@@ -194,8 +194,11 @@ var organize = function(context,type) {
 
 				// Create screen title
 				var screenTitle = MSTextLayer.new();
+				screenTitle.setHorizontalSizing(1);
+				screenTitle.setVerticalSizing(1);
 				screenTitle.setStringValue(groupLayout[i]["prefix"]);
 				screenTitle.setName(groupLayout[i]["prefix"]);
+				screenTitle.adjustFrameToFit();
 
 				if (titleTextAlign == 0) {
 					screenTitle.frame().setY(titleTextY);


### PR DESCRIPTION
Fix _Run Symbol Organizer_ and _Remove Unused Symbols_ actions to run on Sketch version 2025.1 and after.

